### PR TITLE
feat: Add customizable default code snippets 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,40 @@ Item: python, Value: ["Python", "py", "python"]
 
 Enable this to add the Markdown file's parent directory to Python's `sys.path`, allowing you to import modules from that directory.
 
+### Default Codes
+
+By configuring the dictionary `defaultCodes`, you can prepend or wrap your code snippets with default code.
+
+Example `setting.json`:
+```
+{
+    "markdownRunner.defaultCodes": {
+        "cpp": "-I@ #include <bits/stdc++.h>\nusing namespace std;\nint main(){\n@\n}",
+        "bash": "var=123"
+    }
+}
+```
+Notice that the character "@" is a placeholder for other code. It can be replaced by any other character and must be adjacent to "-I" (no space between them).
+
+Execution result with the above settings: 
+````markdown
+```cpp
+cout<<456<<endl;
+```
+
+```result
+456
+```
+
+```
+echo $var
+```
+
+```result
+123
+```
+````
+
 ## Future Development
 
 Planned features (no guarantee):

--- a/package.json
+++ b/package.json
@@ -54,6 +54,14 @@
           "type": "boolean",
           "description": "Enable this to add the Markdown file's parent directory to Python's `sys.path`, allowing you to import modules from that directory.",
           "default": true
+        },
+        "markdownRunner.defaultCodes": {
+          "type": "object",
+          "description": "Specify default codes for specific languages. ",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Enables the seamless execution of code blocks in any language within Markdown files in VS Code",
   "publisher": "renathossain",
   "icon": "Icon.png",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/codeRunner.ts
+++ b/src/codeRunner.ts
@@ -111,6 +111,18 @@ function injectPythonPath(language: string, code: string): string {
     return code;
 }
 
+function injectDefaultCode(language: string, code: string): string {
+    const config = vscode.workspace.getConfiguration();
+    const defCodeConfig = config.get<any>('markdownRunner.defaultCodes');
+    const defaultCode = defCodeConfig.hasOwnProperty(language) ? defCodeConfig[language] : "";
+    const match = /^-I(.) ([\s\S]+$)/.exec(defaultCode);
+    if(match) {
+        return match[2].replace(match[1], code);
+    } else {
+        return defaultCode + "\n" + code;
+    }
+}
+
 // Save code to a temporary file and execute it
 // For compiled languages, a child process is created for compilation additionally
 // Return command string to be run in terminal or on markdown file as needed
@@ -121,7 +133,8 @@ export async function getRunCommand(language: string, code: string): Promise<str
     if (!extension) { return ''; }
     const compiler = getLanguageConfig(language, 'compiler');
     if (!compiler) { return ''; }
-    code = injectPythonPath(language, code);
+
+    code = injectDefaultCode(language, injectPythonPath(language, code));
     const basePath = path.join(os.tmpdir(), baseName);
     const uncompiledPath = `${basePath}.${extension}`;
 


### PR DESCRIPTION
- Introduce `defaultCodes` config property
- Enable each language to specify its own default code snippets via `defaultCodes`