### PR TITLE
Custom Command Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This extension allows you to execute code blocks in any programming language dir
 - **Execute Code Snippets**: Run code snippets (enclosed in `) with Ctrl + Click. Results appear in the terminal. Copy snippets using the hover tooltip.
 - **Save Execution Results**: Capture the output of executing a code block directly within the Markdown document.
 - **Broad Language Support**: Supports a wide range of languages, including C, Rust, C++, Java, TypeScript, PHP, Perl, R, Dart, Groovy, Go, Haskell, Julia, Lua, Ruby, JavaScript, Python, Bash, PowerShell. Add non-compiled languages via settings.
+- **Custom Command Support**: Configure custom shell commands for each language using `markdownRunner.cmdConfiguration` for more control over code execution.
+- **Shell Script Integration**: Use custom shell scripts to execute code blocks by either adding them to the Compiler Configuration or using the new Custom Command Configuration.
 
 ## Requirements
 
@@ -72,6 +74,19 @@ Item: `python`, Value: `["Python", "py", "python"]`
 ```
 
 Reset settings using the ↻ icons or remove the `markdownRunner.compilerConfiguration` entry from VSCode's `settings.json` to restore to default if any issues occur.
+
+### Custom Command Configuration
+
+Configure custom shell commands for each `Language (Code Block Tag)` to execute code blocks. The command will receive the temporary file path as its last argument. If specified, this command will be used instead of the default compilation/execution process and has higher priority than the custom shell script in Compiler Configuration.
+
+```plaintext
+// Example
+Item: `python`, Value: `python3 -u`
+Item: `bash`, Value: `bash -x`
+Item: `python`, Value: `/path/to/script.sh` // Using a custom script
+```
+
+This configuration provides a simpler way to specify custom commands compared to modifying the Compiler Configuration array.
 
 ### Python Path
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "icon": "Icon.png",
   "version": "2.5.0",
   "engines": {
-    "vscode": "^1.106.1"
+    "vscode": "^1.100.0"
   },
   "categories": [
     "Other"
@@ -65,6 +65,14 @@
           },
           "default": {}
         },
+        "markdownRunner.cmdConfiguration": {
+          "type": "object",
+          "description": "Configure custom shell commands for each `Language (Code Block Tag)` to execute code blocks. The command will receive the temporary file path as its last argument. If specified, this command will be used instead of the default compilation/execution process.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
         "markdownRunner.activateOnQuarto": {
           "type": "boolean",
           "description": "Enable to activate the extension on Quarto (.qmd) files.",
@@ -90,7 +98,7 @@
     "@eslint/markdown": "^7.5.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "24.x",
-    "@types/vscode": "^1.106.1",
+    "@types/vscode": "^1.100.0",
     "@typescript-eslint/eslint-plugin": "^8.48.1",
     "@typescript-eslint/parser": "^8.48.1",
     "@vscode/test-cli": "^0.0.12",

--- a/src/runInTerminal.ts
+++ b/src/runInTerminal.ts
@@ -19,7 +19,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as cp from "child_process";
-import { getLanguageConfig } from "./settings";
+import { getLanguageConfig, getCustomCommand } from "./settings";
 import { tempFilePaths } from "./extension";
 
 // Obtain the correct executable name given language and code
@@ -92,6 +92,7 @@ export async function getRunCommand(
   const baseName = getBaseName(language, code);
   const extension = getLanguageConfig(language, "extension");
   const compiler = getLanguageConfig(language, "compiler");
+  const customCommand = getCustomCommand(language);
   if (!baseName || !compiler || !extension) return "";
   code = injectDefaultCode(language, code);
   const basePath = path.join(os.tmpdir(), baseName);
@@ -100,6 +101,12 @@ export async function getRunCommand(
   // Write code to a file, SECURITY: Only Owner Read and Write
   fs.writeFileSync(sourcePath, code, { mode: 0o600 });
   tempFilePaths.push(sourcePath);
+
+  // Check if custom command is defined in cmdConfiguration (highest priority)
+  if (customCommand) {
+    // Use custom command to run the code
+    return `${customCommand} ${sourcePath}`;
+  }
 
   // Compilation for C, C++ and Rust
   if (["c", "cpp", "rust"].includes(language))

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,23 +25,25 @@ import * as vscode from "vscode";
 export function getLanguageConfig(language: string, configuration: string) {
   // Obtain config values for a specific language
   const config = vscode.workspace.getConfiguration();
-  const languageConfig =
-    config.get<{
-      [language: string]: string;
-    }>("markdownRunner.compilerConfiguration") || {};
-  const configValues: string[] =
-    languageConfig[language] &&
-    JSON.parse(languageConfig[language].replace(/'/g, '"'));
+  const languageConfig = config.get<{ [language: string]: string }>("markdownRunner.compilerConfiguration") || {};
+  const configValues: string[] = languageConfig[language] && JSON.parse(languageConfig[language].replace(/'/g, '"'));
 
   // Meaning of each item in the configValues array
   const indexMap: { [key: string]: number } = {
     name: 0,
     extension: 1,
     compiler: 2,
+    shellScript: 3,
   };
 
   // Return the correct configuration
-  return configValues && indexMap[configuration] !== undefined
-    ? configValues[indexMap[configuration]]
-    : undefined;
+  return configValues && indexMap[configuration] !== undefined ? configValues[indexMap[configuration]] : undefined;
+}
+
+// Return the custom command for a specific language
+export function getCustomCommand(language: string): string | undefined {
+  // Obtain custom command for a specific language
+  const config = vscode.workspace.getConfiguration();
+  const cmdConfig = config.get<{ [language: string]: string }>("markdownRunner.cmdConfiguration") || {};
+  return cmdConfig[language];
 }


### PR DESCRIPTION
### Custom Command Configuration

Configure custom shell commands for each `Language (Code Block Tag)` to execute code blocks. The command will receive the temporary file path as its last argument. If specified, this command will be used instead of the default compilation/execution process and has higher priority than the custom shell script in Compiler Configuration.

```plaintext
// Example
Item: `python`, Value: `python3 -u`
Item: `bash`, Value: `bash -x`
Item: `python`, Value: `/path/to/script.sh` // Using a custom script
```

This configuration provides a simpler way to specify custom commands compared to modifying the Compiler Configuration array.