### PR TITLE
Version 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.7.0
 
+- **Bug Fix**: Removed hardcoded `java` command and now derive runtime from the configured `compiler` path.
 - **Change**: Renamed `result` code block tag to `output` for more conventional naming. Existing `result` blocks are not automatically migrated; users can update them manually using global search and replace (Ctrl + Shift + F).
 
 ## 2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 2.7.0
 
+- **New Feature**: Added configurable "**Output Encoding**" setting to control how process output is decoded in "Run on Markdown". Supports `utf8`, `utf16le`, `latin1`, `ascii`, `base64`, `hex`, and `gbk`, helping fix corrupted non-ASCII output on some systems (e.g. `gbk` on certain Windows setups).
+- **New Feature**: Added support for capturing and displaying `stderr` output in addition to `stdout` when using "Run on Markdown".
+- **Change**: Renamed `result` code block tag to `output` for more conventional naming. Existing `result` blocks are not automatically migrated; users can update them manually using global search and replace (Ctrl + Shift + F).
 - **Bug Fix**: Removed hardcoded `java` command and now derive runtime from the configured `compiler` path.
 - **Bug Fix**: Fixed duplicated compiler error messages.
-- **Change**: Renamed `result` code block tag to `output` for more conventional naming. Existing `result` blocks are not automatically migrated; users can update them manually using global search and replace (Ctrl + Shift + F).
-- **New Feature**: Added support for capturing and displaying `stderr` output in addition to `stdout` when using "Run on Markdown".
 
 ## 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## 2.7.0
 
 - **Bug Fix**: Removed hardcoded `java` command and now derive runtime from the configured `compiler` path.
+- **Bug Fix**: Fixed duplicated compiler error messages.
 - **Change**: Renamed `result` code block tag to `output` for more conventional naming. Existing `result` blocks are not automatically migrated; users can update them manually using global search and replace (Ctrl + Shift + F).
+- **New Feature**: Added support for capturing and displaying `stderr` output in addition to `stdout` when using "Run on Markdown".
 
 ## 2.6.0
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ cout << 456 << endl;
 
 Enable to activate the extension on Quarto (.qmd) files.
 
+### Output Encoding
+
+Encoding used to decode `Run on Markdown` process output. Supports `utf8`, `utf16le`, `latin1`, `ascii`, `base64`, `hex`, and `gbk`. Change this if non-ASCII characters appear corrupted (e.g. change to `gbk` on some Windows systems).
+
 ## Future Development
 
 Planned features (no guarantee):

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "markdown-runner",
       "version": "2.7.0",
       "dependencies": {
+        "iconv-lite": "^0.7.2",
         "semaphore-async-await": "^1.5.1",
         "tree-kill": "^1.2.2"
       },
@@ -3887,6 +3888,19 @@
         "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5061,16 +5075,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -8264,7 +8281,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -9826,6 +9842,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "properties": {
         "markdownRunner.compilerConfiguration": {
           "type": "object",
-          "description": "Configure language compilers by specifying for each `Language (Code Block Tag)`, the following value: `[Language Name, File Extension, Compiler Command/Path]`. Only non-compiled languages can be added.",
+          "description": "Configure language compilers by specifying for each `Language (Code Block Tag)`, the following value: `[Language Name, File Extension, Compiler Command/Path]`. Only non-compiled languages can be added. Reset settings using the ↻ icons that appear when hovering on each setting.",
           "additionalProperties": {
             "type": "string"
           },
@@ -69,6 +69,20 @@
           "type": "boolean",
           "description": "Enable to activate the extension on Quarto (.qmd) files.",
           "default": true
+        },
+        "markdownRunner.outputEncoding": {
+          "type": "string",
+          "enum": [
+            "utf8",
+            "utf16le",
+            "latin1",
+            "ascii",
+            "base64",
+            "hex",
+            "gbk"
+          ],
+          "default": "utf8",
+          "description": "Encoding used to decode `Run on Markdown` process output. Supports `utf8`, `utf16le`, `latin1`, `ascii`, `base64`, `hex`, and `gbk`. Change this if non-ASCII characters appear corrupted (e.g. change to `gbk` on some Windows systems)."
         }
       }
     },
@@ -119,6 +133,7 @@
     "webpack-cli": "^7.0.2"
   },
   "dependencies": {
+    "iconv-lite": "^0.7.2",
     "semaphore-async-await": "^1.5.1",
     "tree-kill": "^1.2.2"
   }

--- a/src/runInTerminal.ts
+++ b/src/runInTerminal.ts
@@ -70,11 +70,10 @@ function injectDefaultCode(language: string, code: string) {
 const compile = (cmd: string, out: string) => (
   tempFilePaths.push(out),
   new Promise<boolean>((resolve) =>
-    // e - error, s - stdout, se - stderr
-    cp.exec(cmd, (e, s, se) => {
-      if (e || se)
-        vscode.window.showErrorMessage(`${e ?? ""}${s ?? ""}${se ?? ""}`);
-      resolve(!e);
+    cp.exec(cmd, (error, _, stderr) => {
+      const errorMsg = stderr || error?.message;
+      if (errorMsg) vscode.window.showErrorMessage(errorMsg);
+      resolve(!error);
     }),
   )
 );

--- a/src/runInTerminal.ts
+++ b/src/runInTerminal.ts
@@ -107,7 +107,7 @@ export async function getRunCommand(language: string, code: string) {
   // Compilation for Java
   if (language === "java")
     return (await compile(`${compiler} ${sourcePath}`, `${basePath}.class`))
-      ? `java -cp ${os.tmpdir()} ${baseName}`
+      ? `${compiler.replace(/javac$/, "java")} -cp ${os.tmpdir()} ${baseName}`
       : "";
 
   // Compilation for TypeScript

--- a/src/runOnMarkdown.ts
+++ b/src/runOnMarkdown.ts
@@ -16,6 +16,7 @@
 
 import * as vscode from "vscode";
 import * as cp from "child_process";
+import iconv from "iconv-lite";
 import Mutex from "semaphore-async-await";
 import treeKill from "tree-kill";
 import { parseBlock, blockRegex } from "./codeLens";
@@ -105,11 +106,16 @@ export function runOnMarkdown(code: string, range: vscode.Range) {
     // Output child process 3 lines below parent code block
     let outputPos = new vscode.Position(range.end.line + 3, 0);
 
+    // Obtain correct encoder
+    const encoding = vscode.workspace
+      .getConfiguration()
+      .get<string>("markdownRunner.outputEncoding", "utf8");
+
     // Whenever child process outputs a new batch of data, write it
     const writer = async (data: Buffer) => {
       await outputMutex.acquire();
 
-      const output = data.toString();
+      const output = iconv.decode(data, encoding);
       await editor.edit((text) => text.insert(outputPos, output));
       const lines = output.split("\n");
       const last = lines[lines.length - 1];

--- a/src/runOnMarkdown.ts
+++ b/src/runOnMarkdown.ts
@@ -37,6 +37,16 @@ killAllButton.command = {
 };
 killAllButton.text = "$(stop-circle) Kill All Processes";
 
+// Delete selected range in text
+export async function deleteOnMarkdown(range: vscode.Range) {
+  if (!textEditMutex.tryAcquire()) return;
+  const editor = vscode.window.activeTextEditor;
+  if (await editor?.edit((text) => text.delete(range)))
+    await editor?.document.save();
+  codeLensProvider?.refresh();
+  textEditMutex.release();
+}
+
 // Used for `Run on Markdown`
 function findOutputBlock(document: vscode.TextDocument, startLine: number) {
   // Check if startLine is out of bounds
@@ -59,15 +69,6 @@ function findOutputBlock(document: vscode.TextDocument, startLine: number) {
   // Return range of output block's contents to be cleared
   const endLine = startLine + code.split("\n").length;
   return new vscode.Range(startLine + 1, 0, endLine, 0);
-}
-
-// Delete selected range in text
-export async function deleteOnMarkdown(range: vscode.Range) {
-  if (!textEditMutex.tryAcquire()) return;
-  const editor = vscode.window.activeTextEditor;
-  if (await editor?.edit((text) => text.delete(range)))
-    await editor?.document.save();
-  textEditMutex.release();
 }
 
 // Run command on the markdown file
@@ -156,12 +157,13 @@ export function runOnMarkdown(code: string, range: vscode.Range) {
     outputMutex.release();
     await exitMutex.acquire();
     await endMutex.acquire();
-    textEditMutex.release();
-    exitMutex.release();
-    endMutex.release();
 
     // Refresh CodeLenses after finished process
     codeLensProvider?.refresh();
+
+    textEditMutex.release();
+    exitMutex.release();
+    endMutex.release();
   })();
 
   return { pid: child.pid, done };

--- a/src/runOnMarkdown.ts
+++ b/src/runOnMarkdown.ts
@@ -106,7 +106,7 @@ export function runOnMarkdown(code: string, range: vscode.Range) {
     let outputPos = new vscode.Position(range.end.line + 3, 0);
 
     // Whenever child process outputs a new batch of data, write it
-    child.stdout.on("data", async (data: Buffer) => {
+    const writer = async (data: Buffer) => {
       await outputMutex.acquire();
 
       const output = data.toString();
@@ -119,7 +119,10 @@ export function runOnMarkdown(code: string, range: vscode.Range) {
       );
 
       outputMutex.release();
-    });
+    };
+
+    child.stdout.on("data", writer);
+    child.stderr.on("data", writer);
 
     // Runs when child process exits (but not all data may be written)
     child.on("exit", async () => {

--- a/src/test/tests.test.ts
+++ b/src/test/tests.test.ts
@@ -184,7 +184,7 @@ suite("Run File", function () {
 
 suite("Run on Markdown", function () {
   this.timeout(60000);
-  const output = "```output\n82\n```";
+  const output = "82";
   suiteSetup(setup);
 
   const javaCode = `public class Main{public static void main(String[]a){System.out.println(10+72);}}`;
@@ -228,7 +228,10 @@ suite("Run on Markdown", function () {
     }>("markdown.runOnMarkdown", lang, code, range);
     await done;
 
-    assert.strictEqual(doc.getText(), codeBlock + "\n" + output + "\n");
+    assert.match(
+      doc.getText(),
+      new RegExp(`\n\`\`\`output\n(.*)${output}\n\`\`\`\n`, "s"),
+    );
   }
 
   cases.forEach(([name, lang, code]) => {


### PR DESCRIPTION
**New Feature**: Added configurable "**Output Encoding**" setting to control how process output is decoded in "Run on Markdown". Supports `utf8`, `utf16le`, `latin1`, `ascii`, `base64`, `hex`, and `gbk`, helping fix corrupted non-ASCII output on some systems (e.g. `gbk` on certain Windows setups). Fixes #25.